### PR TITLE
Update objective_function_input_checks.R to remove null dependent-arg-function bug

### DIFF
--- a/R/objective_function_input_checks.R
+++ b/R/objective_function_input_checks.R
@@ -174,8 +174,10 @@ check_args_to_vary <- function(
         cat('\nThe independent arguments and their initial values:\n\n')
         utils::str(independent_args)
 
-        cat('\nThe dependent arguments and their initial values:\n\n')
-        utils::str(dependent_arg_function(independent_args))
+        if(!is.null(dependent_arg_function)){
+            cat('\nThe dependent arguments and their initial values:\n\n')
+            utils::str(dependent_arg_function(independent_args))
+        }
     }
 
     # Make sure no drivers were specified


### PR DESCRIPTION
This PR fixes #14. It's a same change that adds another check `is.null`, although there might be a way to only check once if `dependent_arg_function` is null. You can merge  if/when  satisfied. 