### PR TITLE
Remove combine lists

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,5 +23,5 @@ VignetteBuilder: knitr
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-URL: https://github.com/BioCro/BioCroValidation, https://biocro.github.io/BioCroValidation/
+URL: https://github.com/BioCro/BioCroValidation, https://biocro.org/BioCroValidation/
 Config/testthat/edition: 3

--- a/R/combine_lists.R
+++ b/R/combine_lists.R
@@ -1,9 +1,0 @@
-# Helping function for overwriting elements of a base list with elements of a
-# second list; here we assume that both lists have names, and that the names of
-# new_list is a subset of the names of base_list
-combine_lists <- function(base_list, new_list) {
-    for (element_name in names(new_list)) {
-        base_list[[element_name]] <- new_list[[element_name]]
-    }
-    base_list
-}

--- a/R/objective_function_helpers.R
+++ b/R/objective_function_helpers.R
@@ -46,13 +46,13 @@ get_model_runner <- function(
     # Build the runner
     tryCatch({
             partial_func <- BioCro::partial_run_biocro(
-                combine_lists(
+                utils::modifyList(
                     base_model_definition[['initial_values']],
-                    ddp[['initial_values']]
+                    c(list(), ddp[['initial_values']])
                 ),
-                combine_lists(
+                utils::modifyList(
                     base_model_definition[['parameters']],
-                    ddp[['parameters']]
+                    c(list(), ddp[['parameters']])
                 ),
                 ddp[['drivers']],
                 base_model_definition[['direct_modules']],

--- a/R/objective_function_input_checks.R
+++ b/R/objective_function_input_checks.R
@@ -235,13 +235,13 @@ check_data_driver_pairs <- function(base_model_definition, data_driver_pairs, ve
     # base model definition
     valid_definitions <- sapply(data_driver_pairs, function(ddp) {
         BioCro::validate_dynamical_system_inputs(
-            combine_lists(
+            utils::modifyList(
                 base_model_definition[['initial_values']],
-                ddp[['initial_values']]
+                c(list(), ddp[['initial_values']])
             ),
-            combine_lists(
+            utils::modifyList(
                 base_model_definition[['parameters']],
-                ddp[['parameters']]
+                c(list(), ddp[['parameters']])
             ),
             ddp[['drivers']],
             base_model_definition[['direct_modules']],

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ from within R by typing `install.packages('remotes')`.
 ### Usage
 
 The best way to learn about using `BioCroValidation` is to visit the
-[BioCroValidation website](https://biocro.github.io/BioCroValidation/index.html)
+[BioCroValidation website](https://biocro.org/BioCroValidation/index.html)
 and click the "Get Started" link in the top menu bar. The website includes
 documentation for all the functions and data sets included in the package, as
 well as articles that describe its general features and several important use


### PR DESCRIPTION
Here I have removed the `combine_lists` function and replaced it with `modifyList` to avoid replicating part of base R.

A key difference between these functions is that the second argument to `modifyList` must be a list, while `combine_lists` allowed it to be `NULL`. If the user does not supply driver-specific parameters or initial values, then `ddp[['parameters']]` or `ddp[['initial_values']]` is `NULL`, causing a problem. To fix this, I changed these arguments to `c(list(), ddp[['parameters']])`, etc, which ensures that a (potentially empty) list is always passed.